### PR TITLE
Fixes the texture point coordinates

### DIFF
--- a/vox/vox_texture.lua
+++ b/vox/vox_texture.lua
@@ -6,8 +6,8 @@ local function getPoints(model)
     len = len + 1
     local color = model.palette[voxel[4]]
     local x,y,z = voxel[1], voxel[2], voxel[3]
-    points[len] = { z * model.sizeX + x,
-                    y,
+    points[len] = { z * model.sizeX + x + 0.5,
+                    y + 0.5,
                     color[1], color[2], color[3], color[4]>0 and color[4] or 255} -- r,g,b,a
   end
   return points


### PR DESCRIPTION
I did not read the [LÖVE wiki section about love.graphics.points](https://love2d.org/wiki/love.graphics.points) correctly. It says there that "The pixel grid is actually offset to the center of each pixel. So to get clean pixels drawn use 0.5 + integer increments.". I have tested this with a small (2x2x2) voxel model and it worked well only after I added the 0.5 increments.